### PR TITLE
fix: isly noy dynamicly imported in build step

### DIFF
--- a/Time/Changeable.ts
+++ b/Time/Changeable.ts
@@ -1,3 +1,6 @@
+// this is used in the build step. isly must be imported
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { isly } from "isly"
 import { Creatable } from "./Creatable"
 
 export type Changeable = Pick<Creatable, keyof Creatable>


### PR DESCRIPTION
without this import the following JS declaration file is generated:
```ts
import { Creatable } from "./Creatable";
export type Changeable = Pick<Creatable, keyof Creatable>;
export declare namespace Changeable {
    const type: import("isly/dist/object").object.ExtendableType<Changeable>;
    const is: import("isly/dist/Type").Type.IsFunction<Changeable>;
    const flaw: import("isly/dist/Type").Type.FlawFunction;
}
```
the imports are resolved to any when imported.

with the isly import in the file the following declaration is generated:
```ts
import { isly } from "isly";
import { Creatable } from "./Creatable";
export type Changeable = Pick<Creatable, keyof Creatable>;
export declare namespace Changeable {
    const type: isly.object.ExtendableType<Changeable>;
    const is: isly.Type.IsFunction<Changeable>;
    const flaw: isly.Type.FlawFunction;
}
```
the consts are now proprly typed and do not resolve to any.