### PR TITLE
fix: state selections

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,8 +32,8 @@
 	"editor.formatOnSave": true,
 	"editor.formatOnPaste": true,
 	"editor.codeActionsOnSave": {
-		"source.fixAll.eslint": true,
-		"eslint.autoFixOnSave": true,
+		"source.fixAll.eslint": "explicit",
+		"eslint.autoFixOnSave": "explicit"
 	},
 	"eslint.format.enable": true,
 	"eslint.lintTask.enable": true,

--- a/Rule/Adjust/Percentage.spec.ts
+++ b/Rule/Adjust/Percentage.spec.ts
@@ -5,7 +5,7 @@ import { Percentage } from "./Percentage"
 import { Span } from "./Span"
 
 describe("Rule.Adjust.Percentage", () => {
-	const { criteria } = Criteria.parse("weekDay:Wednesday")
+	const { criteria } = Criteria.parse("day:Wednesday")
 	it("is", () => {
 		const percentage = new Percentage(criteria, 0.8)
 		expect(Percentage.is(percentage)).toEqual(true)
@@ -29,13 +29,11 @@ describe("Rule.Adjust.Percentage", () => {
 		expect(new Percentage(criteria, 1).evaluate(thursday, time)).not.toBe(time)
 	})
 	it("toString", () => {
-		expect(weekmeter.Rule.parse("adjust 80% weekDay:Wednesday")?.toString()).toEqual("adjust 80% weekDay:Wednesday")
-		expect(weekmeter.Rule.parse("adjust 80.2% weekDay:Wednesday")?.toString()).toEqual("adjust 80.2% weekDay:Wednesday")
-		expect(weekmeter.Rule.parse("adjust 80.02% weekDay:Wednesday")?.toString()).toEqual(
-			"adjust 80.02% weekDay:Wednesday"
-		)
-		expect(weekmeter.Rule.parse("adjust 8% weekDay:Wednesday")?.toString()).toEqual("adjust 8% weekDay:Wednesday")
-		expect(weekmeter.Rule.parse("adjust 8.20% weekDay:Wednesday")?.toString()).toEqual("adjust 8.2% weekDay:Wednesday")
-		expect(weekmeter.Rule.parse("adjust 8.0% weekDay:Wednesday")?.toString()).toEqual("adjust 8% weekDay:Wednesday")
+		expect(weekmeter.Rule.parse("adjust 80% day:Wednesday")?.toString()).toEqual("adjust 80% day:Wednesday")
+		expect(weekmeter.Rule.parse("adjust 80.2% day:Wednesday")?.toString()).toEqual("adjust 80.2% day:Wednesday")
+		expect(weekmeter.Rule.parse("adjust 80.02% day:Wednesday")?.toString()).toEqual("adjust 80.02% day:Wednesday")
+		expect(weekmeter.Rule.parse("adjust 8% day:Wednesday")?.toString()).toEqual("adjust 8% day:Wednesday")
+		expect(weekmeter.Rule.parse("adjust 8.20% day:Wednesday")?.toString()).toEqual("adjust 8.2% day:Wednesday")
+		expect(weekmeter.Rule.parse("adjust 8.0% day:Wednesday")?.toString()).toEqual("adjust 8% day:Wednesday")
 	})
 })

--- a/Rule/Adjust/Span.spec.ts
+++ b/Rule/Adjust/Span.spec.ts
@@ -5,7 +5,7 @@ import { Percentage } from "./Percentage"
 import { Span } from "./Span"
 
 describe("Rule.Adjust.Span", () => {
-	const { criteria } = Criteria.parse("weekDay:Wednesday")
+	const { criteria } = Criteria.parse("day:Wednesday")
 	it("is", () => {
 		const span = new Span(criteria, { hours: 8 })
 		expect(Span.is(span)).toEqual(true)
@@ -38,17 +38,11 @@ describe("Rule.Adjust.Span", () => {
 		expect(new Span(criteria, { hours: 0 }).evaluate(thursday, time)).not.toBe(time)
 	})
 	it("toString", () => {
-		expect(weekmeter.Rule.parse("adjust 8h weekDay:Wednesday")?.toString()).toEqual("adjust 8:00h weekDay:Wednesday")
-		expect(weekmeter.Rule.parse("adjust 8:3h weekDay:Wednesday")?.toString()).toEqual("adjust 8:03h weekDay:Wednesday")
-		expect(weekmeter.Rule.parse("adjust 8:30h weekDay:Wednesday")?.toString()).toEqual("adjust 8:30h weekDay:Wednesday")
-		expect(weekmeter.Rule.parse("adjust 8:300h weekDay:Wednesday")?.toString()).toEqual(
-			"adjust 8:300h weekDay:Wednesday"
-		)
-		expect(weekmeter.Rule.parse("adjust 10:30h weekDay:Wednesday")?.toString()).toEqual(
-			"adjust 10:30h weekDay:Wednesday"
-		)
-		expect(weekmeter.Rule.parse("adjust 100:30h weekDay:Wednesday")?.toString()).toEqual(
-			"adjust 100:30h weekDay:Wednesday"
-		)
+		expect(weekmeter.Rule.parse("adjust 8h day:Wednesday")?.toString()).toEqual("adjust 8:00h day:Wednesday")
+		expect(weekmeter.Rule.parse("adjust 8:3h day:Wednesday")?.toString()).toEqual("adjust 8:03h day:Wednesday")
+		expect(weekmeter.Rule.parse("adjust 8:30h day:Wednesday")?.toString()).toEqual("adjust 8:30h day:Wednesday")
+		expect(weekmeter.Rule.parse("adjust 8:300h day:Wednesday")?.toString()).toEqual("adjust 8:300h day:Wednesday")
+		expect(weekmeter.Rule.parse("adjust 10:30h day:Wednesday")?.toString()).toEqual("adjust 10:30h day:Wednesday")
+		expect(weekmeter.Rule.parse("adjust 100:30h day:Wednesday")?.toString()).toEqual("adjust 100:30h day:Wednesday")
 	})
 })

--- a/Rule/Set.spec.ts
+++ b/Rule/Set.spec.ts
@@ -5,7 +5,7 @@ import { Set } from "./Set"
 import { State } from "./State"
 
 describe("Rule.Set", () => {
-	const { criteria } = Criteria.parse("weekDay:Wednesday")
+	const { criteria } = Criteria.parse("day:Wednesday")
 	it("is", () => {
 		const set = new Set(criteria, { hours: 8 })
 		expect(Set.is(set)).toEqual(true)
@@ -29,11 +29,11 @@ describe("Rule.Set", () => {
 		expect(new Set(criteria, { hours: 8 }).evaluate(thursday, {})).not.toBe(time)
 	})
 	it("toString", () => {
-		expect(weekmeter.Rule.parse("set 8h weekDay:Wednesday")?.toString()).toEqual("set 8:00h weekDay:Wednesday")
-		expect(weekmeter.Rule.parse("set 8:3h weekDay:Wednesday")?.toString()).toEqual("set 8:03h weekDay:Wednesday")
-		expect(weekmeter.Rule.parse("set 8:30h weekDay:Wednesday")?.toString()).toEqual("set 8:30h weekDay:Wednesday")
-		expect(weekmeter.Rule.parse("set 8:300h weekDay:Wednesday")?.toString()).toEqual("set 8:300h weekDay:Wednesday")
-		expect(weekmeter.Rule.parse("set 10:30h weekDay:Wednesday")?.toString()).toEqual("set 10:30h weekDay:Wednesday")
-		expect(weekmeter.Rule.parse("set 100:30h weekDay:Wednesday")?.toString()).toEqual("set 100:30h weekDay:Wednesday")
+		expect(weekmeter.Rule.parse("set 8h day:Wednesday")?.toString()).toEqual("set 8:00h day:Wednesday")
+		expect(weekmeter.Rule.parse("set 8:3h day:Wednesday")?.toString()).toEqual("set 8:03h day:Wednesday")
+		expect(weekmeter.Rule.parse("set 8:30h day:Wednesday")?.toString()).toEqual("set 8:30h day:Wednesday")
+		expect(weekmeter.Rule.parse("set 8:300h day:Wednesday")?.toString()).toEqual("set 8:300h day:Wednesday")
+		expect(weekmeter.Rule.parse("set 10:30h day:Wednesday")?.toString()).toEqual("set 10:30h day:Wednesday")
+		expect(weekmeter.Rule.parse("set 100:30h day:Wednesday")?.toString()).toEqual("set 100:30h day:Wednesday")
 	})
 })

--- a/Rule/State.spec.ts
+++ b/Rule/State.spec.ts
@@ -6,22 +6,20 @@ describe("Rule.State", () => {
 		const state: State = {
 			date: "2023-01-01",
 			year: "2023",
-			month: "1",
-			day: "1",
-			week: "52",
-			weekDay: "Sunday",
+			month: ["1", "01"],
+			day: ["1", "01", "Sunday"],
+			week: ["52", "52"],
 			user: "jessie@rocket.com",
 		}
-		expect(State.is(state))
+		expect(State.is(state)).toEqual(true)
 	})
 	it("create", () => {
 		expect(State.create("2023-01-01", "jessie@rocket.com")).toEqual({
 			date: "2023-01-01",
 			year: "2023",
-			month: "1",
-			day: "1",
-			week: "52",
-			weekDay: "Sunday",
+			month: ["1", "01"],
+			day: ["1", "01", "Sunday"],
+			week: ["52", "52"],
 			user: "jessie@rocket.com",
 		})
 	})

--- a/Rule/State.ts
+++ b/Rule/State.ts
@@ -16,7 +16,7 @@ export namespace State {
 		year: isly.string(/\d+/),
 		month: isly.array(isly.string(/\d+/)),
 		week: isly.array(isly.string(/\d+/)),
-		day: isly.array(isly.string(/\d+/)),
+		day: isly.array(isly.string(/.+/)),
 		user: userwidgets.Email.type,
 	})
 	export const is = type.is

--- a/Rule/State.ts
+++ b/Rule/State.ts
@@ -5,20 +5,18 @@ import { isly } from "isly"
 export interface State {
 	date: string
 	year: string
-	month: string
-	week: string
-	day: string
-	weekDay: string
+	month: string[]
+	week: string[]
+	day: string[]
 	user: string
 }
 export namespace State {
 	export const type = isly.object<State>({
 		date: isly.fromIs("isoly.Date", isoly.Date.is),
 		year: isly.string(/\d+/),
-		month: isly.string(/\d+/),
-		week: isly.string(/\d+/),
-		day: isly.string(/\d+/),
-		weekDay: isly.string(/Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday/),
+		month: isly.array(isly.string(/\d+/)),
+		week: isly.array(isly.string(/\d+/)),
+		day: isly.array(isly.string(/\d+/)),
 		user: userwidgets.Email.type,
 	})
 	export const is = type.is
@@ -27,10 +25,13 @@ export namespace State {
 		return {
 			date,
 			year: isoly.Date.getYear(date).toString(10),
-			month: isoly.Date.getMonth(date).toString(10),
-			week: isoly.Date.getWeek(date).toString(10),
-			day: isoly.Date.getDay(date).toString(10),
-			weekDay: isoly.Date.getWeekDay(date, "en-US", { format: "long" }),
+			month: [isoly.Date.getMonth(date).toString(10), isoly.Date.getMonth(date).toString(10).padStart(2, "0")],
+			week: [isoly.Date.getWeek(date).toString(10), isoly.Date.getWeek(date).toString(10).padStart(2, "0")],
+			day: [
+				isoly.Date.getDay(date).toString(10),
+				isoly.Date.getDay(date).toString(10).padStart(2, "0"),
+				isoly.Date.getWeekDay(date, "en-US", { format: "long" }),
+			],
 			user: user,
 		}
 	}

--- a/Rule/index.spec.ts
+++ b/Rule/index.spec.ts
@@ -60,19 +60,16 @@ describe("Rule", () => {
 	it("numbered, 0-padded and named weekday", () => {
 		const rules = [...fixtures.getRuleArray("8h"), "set 0h day:04 day:4 day:Tuesday"]
 		const result = weekmeter.Rule.expected("jessie@rocket.com", { start: "2023-04-03", end: "2023-04-05" }, rules)
-		console.log(result)
 		expect(isoly.TimeSpan.toHours(result ?? {})).toBeCloseTo(16)
 	})
 	it("numbered and 0-padded month", () => {
 		const rules = [...fixtures.getRuleArray("8h"), "set 0h month:4 month:4"]
 		const result = weekmeter.Rule.expected("jessie@rocket.com", { start: "2023-04-03", end: "2023-04-05" }, rules)
-		console.log(result)
 		expect(isoly.TimeSpan.toHours(result ?? {})).toBeCloseTo(0)
 	})
 	it("numbered and 0-padded week", () => {
 		const rules = [...fixtures.getRuleArray("8h"), "set 0h week:04 week:4"]
 		const result = weekmeter.Rule.expected("jessie@rocket.com", { start: "2023-01-25", end: "2023-01-27" }, rules)
-		console.log(result)
 		expect(isoly.TimeSpan.toHours(result ?? {})).toBeCloseTo(0)
 	})
 })

--- a/Rule/index.spec.ts
+++ b/Rule/index.spec.ts
@@ -14,10 +14,10 @@ describe("Rule", () => {
 		rules.forEach(rule => expect(weekmeter.Rule.is((({ name, ...rule }) => rule)(rule))).toEqual(false))
 	})
 	it("parse", () => {
-		const span = weekmeter.Rule.parse("adjust 8h weekDay:Wednesday")
-		const percentage = weekmeter.Rule.parse("adjust 80% weekDay:Wednesday")
-		const set = weekmeter.Rule.parse("set 8h weekDay:Wednesday")
-		const notSupported = weekmeter.Rule.parse("set 80% weekDay:Wednesday")
+		const span = weekmeter.Rule.parse("adjust 8h day:Wednesday")
+		const percentage = weekmeter.Rule.parse("adjust 80% day:Wednesday")
+		const set = weekmeter.Rule.parse("set 8h day:Wednesday")
+		const notSupported = weekmeter.Rule.parse("set 80% day:Wednesday")
 		expect(Adjust.is(span)).toEqual(true)
 		expect(Adjust.is(percentage)).toEqual(true)
 		expect(Span.is(span)).toEqual(true)
@@ -56,5 +56,23 @@ describe("Rule", () => {
 		]
 		const result = weekmeter.Rule.expected("jessie@rocket.com", { start: "2023-04-03", end: "2023-04-09" }, rules)
 		expect(isoly.TimeSpan.toHours(result ?? {})).toBeCloseTo(22.4)
+	})
+	it("numbered, 0-padded and named weekday", () => {
+		const rules = [...fixtures.getRuleArray("8h"), "set 0h day:04 day:4 day:Tuesday"]
+		const result = weekmeter.Rule.expected("jessie@rocket.com", { start: "2023-04-03", end: "2023-04-05" }, rules)
+		console.log(result)
+		expect(isoly.TimeSpan.toHours(result ?? {})).toBeCloseTo(16)
+	})
+	it("numbered and 0-padded month", () => {
+		const rules = [...fixtures.getRuleArray("8h"), "set 0h month:4 month:4"]
+		const result = weekmeter.Rule.expected("jessie@rocket.com", { start: "2023-04-03", end: "2023-04-05" }, rules)
+		console.log(result)
+		expect(isoly.TimeSpan.toHours(result ?? {})).toBeCloseTo(0)
+	})
+	it("numbered and 0-padded week", () => {
+		const rules = [...fixtures.getRuleArray("8h"), "set 0h week:04 week:4"]
+		const result = weekmeter.Rule.expected("jessie@rocket.com", { start: "2023-01-25", end: "2023-01-27" }, rules)
+		console.log(result)
+		expect(isoly.TimeSpan.toHours(result ?? {})).toBeCloseTo(0)
 	})
 })

--- a/Time/Changeable/Base.spec.ts
+++ b/Time/Changeable/Base.spec.ts
@@ -22,12 +22,13 @@ describe("Time.Changeable.Base", () => {
 		expect(weekmeter.Time.Changeable.Base.type.get(time)).toEqual(base)
 	})
 	it("key with date", () => {
+		const now = isoly.Date.now()
 		const [sick, unpaid, vab, vacation, work] = fixtures.create(1).map(time => weekmeter.Time.Changeable.Base.key(time))
-		expect(sick).toEqual("sick|------o1|jessie@rocket.com|2023-12-11")
-		expect(unpaid).toEqual("unpaid|------o1|jessie@rocket.com|2023-12-11")
-		expect(vab).toEqual("vab|------o1|jessie@rocket.com|2023-12-11")
-		expect(vacation).toEqual("vacation|------o1|jessie@rocket.com|2023-12-11")
-		expect(work).toEqual("work|------o1|jessie@rocket.com|2023-12-11")
+		expect(sick).toEqual(`sick|------o1|jessie@rocket.com|${now}`)
+		expect(unpaid).toEqual(`unpaid|------o1|jessie@rocket.com|${now}`)
+		expect(vab).toEqual(`vab|------o1|jessie@rocket.com|${now}`)
+		expect(vacation).toEqual(`vacation|------o1|jessie@rocket.com|${now}`)
+		expect(work).toEqual(`work|------o1|jessie@rocket.com|${now}`)
 	})
 	it("key no date", () => {
 		const [sick, unpaid, vab, vacation, work] = fixtures

--- a/Time/Changeable/index.spec.ts
+++ b/Time/Changeable/index.spec.ts
@@ -1,3 +1,4 @@
+import { isoly } from "isoly"
 import { weekmeter } from "../../index"
 import * as fixtures from "../fixtures"
 
@@ -8,12 +9,13 @@ describe("Time.Changeable", () => {
 		times.forEach(time => expect(weekmeter.Time.Changeable.type.get(time)).toEqual(time))
 	})
 	it("key with date", () => {
+		const now = isoly.Date.now()
 		const [sick, unpaid, vab, vacation, work] = fixtures.create(1).map(time => weekmeter.Time.Changeable.key(time))
-		expect(sick).toEqual("sick|------o1|jessie@rocket.com|2023-12-11")
-		expect(unpaid).toEqual("unpaid|------o1|jessie@rocket.com|2023-12-11")
-		expect(vab).toEqual("vab|------o1|jessie@rocket.com|2023-12-11")
-		expect(vacation).toEqual("vacation|------o1|jessie@rocket.com|2023-12-11")
-		expect(work).toEqual("work|------o1|jessie@rocket.com|------c1|------p1|------a1|2023-12-11")
+		expect(sick).toEqual(`sick|------o1|jessie@rocket.com|${now}`)
+		expect(unpaid).toEqual(`unpaid|------o1|jessie@rocket.com|${now}`)
+		expect(vab).toEqual(`vab|------o1|jessie@rocket.com|${now}`)
+		expect(vacation).toEqual(`vacation|------o1|jessie@rocket.com|${now}`)
+		expect(work).toEqual(`work|------o1|jessie@rocket.com|------c1|------p1|------a1|${now}`)
 	})
 	it("key no date", () => {
 		const [sick, unpaid, vab, vacation, work] = fixtures

--- a/Time/index.spec.ts
+++ b/Time/index.spec.ts
@@ -9,3 +9,4 @@ describe("Time", () => {
 		times.forEach(time => expect(weekmeter.Time.type.get({ ...time, garbage: true })).toEqual(time))
 	})
 })
+

--- a/Time/index.spec.ts
+++ b/Time/index.spec.ts
@@ -9,4 +9,3 @@ describe("Time", () => {
 		times.forEach(time => expect(weekmeter.Time.type.get({ ...time, garbage: true })).toEqual(time))
 	})
 })
-

--- a/fixtures.ts
+++ b/fixtures.ts
@@ -93,11 +93,11 @@ export function getProjects(n: number): weekmeter.Project[] {
 export const getRuleArray = Object.assign(createRuleArray, {})
 function createRuleArray(time = "8h"): weekmeter.Rule[] {
 	return [
-		{ name: "Monday", value: `set ${time} weekDay:Monday` },
-		{ name: "Tuesday", value: `set ${time} weekDay:Tuesday` },
-		{ name: "Wednesday", value: `set ${time} weekDay:Wednesday` },
-		{ name: "Thursday", value: `set ${time} weekDay:Thursday` },
-		{ name: "Friday", value: `set ${time} weekDay:Friday` },
+		{ name: "Monday", value: `set ${time} day:Monday` },
+		{ name: "Tuesday", value: `set ${time} day:Tuesday` },
+		{ name: "Wednesday", value: `set ${time} day:Wednesday` },
+		{ name: "Thursday", value: `set ${time} day:Thursday` },
+		{ name: "Friday", value: `set ${time} day:Friday` },
 	]
 }
 export const getRules = Object.assign(createRules, { changeable: createRulesChangeable })


### PR DESCRIPTION
changed some properties on the state on which the rule engine operates. 
* the property `weekDay` have been removed and merged with the property `day` as an array. `day` can now be targeted by both a non 0-padded number, a 0-padded number or a name.
* the property month can now be targeted by both a non 0-padded number and a 0-padded number.
* the property week can now be targeted by both a non 0-padded number and a 0-padded number.