### PR TITLE
Project access admin

### DIFF
--- a/Project/Access/Engine/index.spec.ts
+++ b/Project/Access/Engine/index.spec.ts
@@ -44,6 +44,11 @@ describe("Project.Access.Engine", () => {
 		expect(engine?.every("work")).toEqual(false)
 		expect(engine?.every("work", "view")).toEqual(false)
 		expect(engine?.every("view", "work")).toEqual(false)
+		project.access.rules = []
+		engine = weekmeter.Project.Access.Engine.create(project, user)
+		expect(engine?.any()).toEqual(true)
+		expect(engine?.some("view")).toEqual(true)
+		expect(engine?.every("view")).toEqual(true)
 	})
 	it("stringify", () => {
 		const project = { ...fixtures.project.access.engine.state().project, access: fixtures.project.access() }

--- a/Project/Access/Engine/index.spec.ts
+++ b/Project/Access/Engine/index.spec.ts
@@ -13,6 +13,7 @@ describe("Project.Access.Engine", () => {
 		const project = { ...fixtures.project.access.engine.state().project, access: fixtures.project.access() }
 		const user = { email: fixtures.user(), profile: fixtures.user.profile() }
 		engine = weekmeter.Project.Access.Engine.create(project, user)
+		expect(engine?.any()).toEqual(true)
 		expect(engine?.some("work")).toEqual(true)
 		expect(engine?.some("view")).toEqual(true)
 		expect(engine?.some("view", "work")).toEqual(true)
@@ -22,6 +23,7 @@ describe("Project.Access.Engine", () => {
 		expect(engine?.every("view", "work")).toEqual(true)
 		project.access = { rules: ["work if (user.country:SE)", "work if (user.team:Dev)"] }
 		engine = weekmeter.Project.Access.Engine.create(project, user)
+		expect(engine?.any()).toEqual(true)
 		expect(engine?.some("work")).toEqual(true)
 		expect(engine?.some("view")).toEqual(false)
 		expect(engine?.some("view", "work")).toEqual(true)
@@ -33,9 +35,11 @@ describe("Project.Access.Engine", () => {
 			{ name: "department", value: "Sales" },
 		]
 		engine = weekmeter.Project.Access.Engine.create(project, user)
+		expect(engine?.any()).toEqual(false)
 		expect(engine?.some("work")).toEqual(false)
 		expect(engine?.some("view")).toEqual(false)
 		expect(engine?.some("view", "work")).toEqual(false)
+		expect(engine?.some("view", "work", "admin")).toEqual(false)
 		expect(engine?.every("view")).toEqual(false)
 		expect(engine?.every("work")).toEqual(false)
 		expect(engine?.every("work", "view")).toEqual(false)

--- a/Project/Access/Engine/index.ts
+++ b/Project/Access/Engine/index.ts
@@ -1,10 +1,18 @@
 import type { Project } from "../../index"
-import type { Access } from "../index"
+import { Access } from "../index"
 import { Rule as EngineRule } from "./Rule"
 import { State as EngineState, State } from "./State"
 
 export class Engine {
 	private constructor(private state: Engine.State, private rules: Engine.Rule[]) {}
+	any(): boolean {
+		return (
+			this.rules.reduce(
+				(result, rule) => (!rule.is(this.state) ? result : (result.delete(rule.type), result)),
+				new Set<Access.Rule.Type>(Access.Rule.Type.values)
+			).size < Access.Rule.Type.values.length
+		)
+	}
 	some(...types: Access.Rule.Type[]): boolean {
 		return !this.rules.length
 			? true

--- a/Project/Access/Engine/index.ts
+++ b/Project/Access/Engine/index.ts
@@ -6,28 +6,28 @@ import { State as EngineState, State } from "./State"
 export class Engine {
 	private constructor(private state: Engine.State, private rules: Engine.Rule[]) {}
 	any(): boolean {
-		return (
-			this.rules.reduce(
-				(result, rule) => (!rule.is(this.state) ? result : (result.delete(rule.type), result)),
-				new Set<Access.Rule.Type>(Access.Rule.Type.values)
-			).size < Access.Rule.Type.values.length
-		)
+		return this.some(...Access.Rule.Type.values)
 	}
 	some(...types: Access.Rule.Type[]): boolean {
-		return !this.rules.length
-			? true
-			: this.rules.reduce(
-					(result, rule) => (!rule.is(this.state) ? result : (result.delete(rule.type), result)),
-					new Set<Access.Rule.Type>(types)
-			  ).size < types.length
+		let result: Return<Engine["some"]>
+		if (!this.rules.length)
+			result = true
+		else
+			result = !!this.rules.find(rule => rule.is(this.state) && types.includes(rule.type))
+		return result
 	}
 	every(...types: Access.Rule.Type[]): boolean {
-		return !this.rules.length
-			? true
-			: this.rules.reduce(
-					(result, rule) => (!rule.is(this.state) ? result : (result.delete(rule.type), result)),
-					new Set<Access.Rule.Type>(types)
-			  ).size == 0
+		let result: Return<Engine["every"]>
+		if (!this.rules.length)
+			result = true
+		else
+			for (
+				let [index, remainder] = [0, new Set(types)];
+				!(result = !remainder.size) && index < this.rules.length;
+				index++
+			)
+				this.rules[index].is(this.state) && remainder.delete(this.rules[index].type)
+		return result
 	}
 	stringify(): Access.Rule[] {
 		return this.rules.map(rule => rule.stringify())

--- a/Project/Access/Rule/Type/Admin.spec.ts
+++ b/Project/Access/Rule/Type/Admin.spec.ts
@@ -1,0 +1,11 @@
+import { weekmeter } from "../../../../index"
+
+describe("Project.Access.Rule.Type.Admin", () => {
+	it("value", () => {
+		const value: weekmeter.Project.Access.Rule.Type.Admin = weekmeter.Project.Access.Rule.Type.Admin.value
+		expect(value).toEqual("admin")
+	})
+	it("is", () => {
+		expect(weekmeter.Project.Access.Rule.Type.Admin.is(weekmeter.Project.Access.Rule.Type.Admin.value))
+	})
+})

--- a/Project/Access/Rule/Type/Admin.ts
+++ b/Project/Access/Rule/Type/Admin.ts
@@ -1,0 +1,9 @@
+import { isly } from "isly"
+
+export type Admin = typeof Admin.value
+export namespace Admin {
+	export const value = "admin" as const
+	export const type = isly.string<Admin>(value)
+	export const is = type.is
+	export const flaw = type.flaw
+}

--- a/Project/Access/Rule/Type/index.spec.ts
+++ b/Project/Access/Rule/Type/index.spec.ts
@@ -3,5 +3,18 @@ import { weekmeter } from "../../../../index"
 describe("Project.Access.Rule.Type", () => {
 	it("is", () => {
 		expect(weekmeter.Project.Access.Rule.Type.is(weekmeter.Project.Access.Rule.Type.Work.value)).toEqual(true)
+		expect(weekmeter.Project.Access.Rule.Type.is(weekmeter.Project.Access.Rule.Type.View.value)).toEqual(true)
+		expect(weekmeter.Project.Access.Rule.Type.is(weekmeter.Project.Access.Rule.Type.Admin.value)).toEqual(true)
+	})
+	it("values", () => {
+		expect(weekmeter.Project.Access.Rule.Type.values.includes(weekmeter.Project.Access.Rule.Type.Work.value)).toEqual(
+			true
+		)
+		expect(weekmeter.Project.Access.Rule.Type.values.includes(weekmeter.Project.Access.Rule.Type.View.value)).toEqual(
+			true
+		)
+		expect(weekmeter.Project.Access.Rule.Type.values.includes(weekmeter.Project.Access.Rule.Type.Admin.value)).toEqual(
+			true
+		)
 	})
 })

--- a/Project/Access/Rule/Type/index.ts
+++ b/Project/Access/Rule/Type/index.ts
@@ -1,15 +1,18 @@
 import { isly } from "isly"
+import { Admin as TypeAdmin } from "./Admin"
 import { View as TypeView } from "./View"
 import { Work as TypeWork } from "./Work"
 
-export type Type = Type.Work | Type.View
+export type Type = Type.Work | Type.View | Type.Admin
 export namespace Type {
 	export type Work = TypeWork
 	export const Work = TypeWork
 	export type View = TypeView
 	export const View = TypeView
-	export const type = isly.union<Type, Type.Work, Type.View>(Work.type, View.type)
+	export type Admin = TypeAdmin
+	export const Admin = TypeAdmin
+	export const type = isly.union<Type, Type.Work, Type.View, Type.Admin>(Work.type, View.type, Admin.type)
 	export const is = type.is
 	export const flaw = type.flaw
-	export const values = [Work.value, View.value] as const
+	export const values = [Work.value, View.value, Admin.value] as const
 }

--- a/Project/Access/Rule/fixtures.ts
+++ b/Project/Access/Rule/fixtures.ts
@@ -8,6 +8,7 @@ export const rule = Object.assign(createRule, {
 		"work if (project.code:weekmeter)",
 		"work if (project.activities:some(code:sprint))",
 		"view if (user.department:Development)",
+		"admin if (user.department:Development)",
 	],
 })
 function createRule(): Rule {

--- a/Project/Access/Rule/index.ts
+++ b/Project/Access/Rule/index.ts
@@ -8,6 +8,7 @@ export namespace Rule {
 	export namespace Type {
 		export type Work = RuleType.Work
 		export type View = RuleType.View
+		export type Admin = RuleType.Admin
 	}
 	export const pattern = new RegExp(`^(${Type.values.join("|")}) if \\((.+)\\)$`)
 	export const type = isly.string<Rule>(pattern)

--- a/Project/Access/index.ts
+++ b/Project/Access/index.ts
@@ -13,6 +13,7 @@ export namespace Access {
 		export namespace Type {
 			export type Work = AccessRule.Type.Work
 			export type View = AccessRule.Type.View
+			export type Admin = AccessRule.Type.Admin
 		}
 	}
 	export type Engine = AccessEngine

--- a/Project/index.ts
+++ b/Project/index.ts
@@ -26,6 +26,7 @@ export namespace Project {
 			export namespace Type {
 				export type Work = ProjectAccess.Rule.Type.Work
 				export type View = ProjectAccess.Rule.Type.View
+				export type Admin = ProjectAccess.Rule.Type.Admin
 			}
 		}
 		export type Engine = ProjectAccess.Engine


### PR DESCRIPTION
* added `Project.Access.Rule.Type` of type `admin`. users with this access can manage this specific project. 
* added `Project.Acccess.Engine.some()` method to make it easier to ask for any permission. useful when checking if a user is allowed to view the resource. any access level should allow the user to view it.